### PR TITLE
Extending requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ Simple way to do this on a Debian-based OS is:
 
 .. code-block:: shell
 
-  sudo apt-get install python-pip python-dev build-essential
+  sudo apt-get install python-pip python-dev build-essential libssl-dev libffi-dev
   sudo pip install -r requirements.txt
   
 And finally start the honeypot:


### PR DESCRIPTION
I've installed heralding on an AWS EC2 instance (with Ubuntu) and on a Raspberry Pi (Raspbian) and it was missing these two dependencies in both cases (I got errors about the cryptography package, and found this solution [here](http://stackoverflow.com/a/22210069))