### PR TITLE
Socks5 and PEP8 cleanups.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ About
 -----
 
 Sometimes you just want a simple honeypot that collects credentials, nothing more. Heralding is that honeypot!
-Currently the following protocols are supported: ftp, telnet, ssh, http, https, pop3, pop3s, imap, imaps, smtp and postgresql.
+Currently the following protocols are supported: ftp, telnet, ssh, http, https, pop3, pop3s, imap, imaps, smtp, vnc, postgresql and socks5.
 
 **You need Python 3.5.0 or higher.**
 
@@ -108,4 +108,3 @@ Pcaps
 Want a seperate pcap for each heralding session? Sure, take a look at the Curisoum_ project. Make sure to enable Curisoum in Heralding.yml!
 
 .. _Curisoum: https://github.com/johnnykv/curiosum
-  

--- a/heralding/capabilities/imap.py
+++ b/heralding/capabilities/imap.py
@@ -158,7 +158,7 @@ class Imap(HandlerBase):
             return True, str(result, 'utf-8')
         except binascii.Error:
             logger.warning('Error decoding base64: {0} '
-                           '({1})',binascii.hexlify(b64_str), session.id)
+                           '({1})', binascii.hexlify(b64_str), session.id)
             return False, ''
 
     @staticmethod

--- a/heralding/capabilities/socks5.py
+++ b/heralding/capabilities/socks5.py
@@ -45,11 +45,13 @@ class Socks5(HandlerBase):
                 await self.do_authenticate(reader, writer, session)
             else:
                 writer.write(SOCKS_VERSION + SOCKS_FAIL)
+                await writer.drain()
         else:
             logger.debug("Wrong socks version: %r" % version)
 
     async def do_authenticate(self, reader, writer, session):
         writer.write(SOCKS_VERSION + AUTH_METHOD)
+        await writer.drain()
         # 513 - max bytes number for username/password auth according to RFC 1929
         auth_data = await reader.read(513)
         if len(auth_data) > 4:
@@ -57,6 +59,7 @@ class Socks5(HandlerBase):
             session.add_auth_attempt('plaintext', username=username.decode(),
                                      password=password.decode())
             writer.write(AUTH_METHOD + SOCKS_FAIL)
+            await writer.drain()
         else:
             logger.debug("Wrong authentication data: %r" % auth_data)
 

--- a/heralding/capabilities/socks5.py
+++ b/heralding/capabilities/socks5.py
@@ -1,0 +1,76 @@
+# Copyright (C) 2018 Roman Samoilenko <ttahabatt@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+
+from heralding.capabilities.handlerbase import HandlerBase
+
+# Socks constants
+SOCKS_VERSION = b'\x05'
+AUTH_METHOD = b'\x02'  # username/password authentication. RFC 1929
+SOCKS_FAIL = b'\xFF'
+
+logger = logging.getLogger(__name__)
+
+
+class Socks5(HandlerBase):
+    async def execute_capability(self, reader, writer, session):
+        await self._handle_session(reader, writer, session)
+
+    async def _handle_session(self, reader, writer, session):
+        # 257 - max bytes number for greeting according to RFC 1928
+        greeting = await reader.read(257)
+        if len(greeting) > 2:
+            await self.try_authenticate(reader, writer, session, greeting)
+        else:
+            logger.debug("Incorrect client greeting string.")
+        session.end_session()
+
+    async def try_authenticate(self, reader, writer, session, greeting):
+        version, authmethods = self.unpack_msg(greeting)
+        if version == SOCKS_VERSION:
+            if AUTH_METHOD in authmethods:
+                await self.do_authenticate(reader, writer, session)
+            else:
+                writer.write(SOCKS_VERSION + SOCKS_FAIL)
+        else:
+            logger.debug("Wrong socks version.")
+
+    async def do_authenticate(self, reader, writer, session):
+        writer.write(SOCKS_VERSION + AUTH_METHOD)
+        # 513 - max bytes number for username/password auth according to RFC 1929
+        auth_data = await reader.read(513)
+        if len(auth_data) > 4:
+            username, password = self.unpack_auth(auth_data)
+            session.add_auth_attempt('plaintext', username=username.decode(),
+                                     password=password.decode())
+            writer.write(AUTH_METHOD + SOCKS_FAIL)
+        else:
+            logger.debug("Wrong authentication data.")
+
+    @staticmethod
+    def unpack_msg(data):
+        socks_version = data[:1]  # we need byte representation
+        authmethods_n = data[1]
+        authmethods = data[2:2+authmethods_n]
+        return socks_version, authmethods
+
+    @staticmethod
+    def unpack_auth(auth_data):
+        ulen = auth_data[1]
+        username = auth_data[2:2+ulen]
+        plen = auth_data[2+ulen:2+ulen+1][0]
+        password = auth_data[-plen:]
+        return username, password

--- a/heralding/capabilities/socks5.py
+++ b/heralding/capabilities/socks5.py
@@ -35,7 +35,7 @@ class Socks5(HandlerBase):
         if len(greeting) > 2:
             await self.try_authenticate(reader, writer, session, greeting)
         else:
-            logger.debug("Incorrect client greeting string.")
+            logger.debug("Incorrect client greeting string: %r" % greeting)
         session.end_session()
 
     async def try_authenticate(self, reader, writer, session, greeting):
@@ -46,7 +46,7 @@ class Socks5(HandlerBase):
             else:
                 writer.write(SOCKS_VERSION + SOCKS_FAIL)
         else:
-            logger.debug("Wrong socks version.")
+            logger.debug("Wrong socks version: %r" % version)
 
     async def do_authenticate(self, reader, writer, session):
         writer.write(SOCKS_VERSION + AUTH_METHOD)
@@ -58,7 +58,7 @@ class Socks5(HandlerBase):
                                      password=password.decode())
             writer.write(AUTH_METHOD + SOCKS_FAIL)
         else:
-            logger.debug("Wrong authentication data.")
+            logger.debug("Wrong authentication data: %r" % auth_data)
 
     @staticmethod
     def unpack_msg(data):

--- a/heralding/capabilities/vnc.py
+++ b/heralding/capabilities/vnc.py
@@ -29,9 +29,6 @@ logger = logging.getLogger(__name__)
 
 
 class Vnc(HandlerBase):
-    def __init__(self, options, loop):
-        super().__init__(options, loop)
-
     async def execute_capability(self, reader, writer, session):
         await self._handle_session(reader, writer, session)
 

--- a/heralding/heralding.yml
+++ b/heralding/heralding.yml
@@ -75,7 +75,7 @@ capabilities:
     enabled: true
     port: 5432
     timeout: 30
- 
+
   imap:
     enabled: true
     port: 143
@@ -149,4 +149,9 @@ capabilities:
   vnc:
     enabled: true
     port: 5900
+    timeout: 30
+
+  socks5:
+    enabled: true
+    port: 1080
     timeout: 30

--- a/heralding/honeypot.py
+++ b/heralding/honeypot.py
@@ -98,7 +98,6 @@ class Honeypot:
                 self.hpfeeds_logger_task = self.loop.run_in_executor(None, curiosum_integration.start)
                 self.hpfeeds_logger_task.add_done_callback(common.on_unhandled_task_exception)
 
-
         bind_host = self.config['bind_host']
         listen_ports = []
         for c in heralding.capabilities.handlerbase.HandlerBase.__subclasses__():
@@ -149,15 +148,15 @@ class Honeypot:
                     self.loop.run_until_complete(common.cancel_all_pending_tasks(self.loop))
                     sys.exit(error_message)
                 else:
-                    logger.info('Started %s capability listening on port %s',c.__name__, port)
+                    logger.info('Started %s capability listening on port %s', c.__name__, port)
         ReportingRelay.logListenPorts(listen_ports)
 
     def stop(self):
         """Stops services"""
         if self.config['capabilities']['ssh']['enabled']:
-           for conn in self.SshClass.connections_list:
-               conn.close()
-               self.loop.run_until_complete(conn.wait_closed())
+            for conn in self.SshClass.connections_list:
+                conn.close()
+                self.loop.run_until_complete(conn.wait_closed())
 
         for server in self._servers:
             server.close()

--- a/heralding/misc/session.py
+++ b/heralding/misc/session.py
@@ -49,7 +49,6 @@ class Session:
         entry = self.get_session_info(False)
         ReportingRelay.logSessionInfo(entry)
 
-
     def activity(self):
         self.last_activity = datetime.utcnow()
 
@@ -82,20 +81,20 @@ class Session:
         self.activity()
         logger.debug('%s authentication attempt from %s:%s. Auth mechanism: %s, session id %s '
                      'Credentials: %s', self.protocol, self.source_ip,
-                                               self.source_port, _type, self.id, json.dumps(kwargs))
+                     self.source_port, _type, self.id, json.dumps(kwargs))
 
     def get_session_info(self, session_ended):
         entry = {'timestamp': self.timestamp,
-                     'duration': (int)((datetime.utcnow() - self.timestamp).total_seconds()),
-                     'session_id': self.id,
-                     'source_ip': self.source_ip,
-                     'source_port': self.source_port,
-                     'destination_ip': heralding.honeypot.Honeypot.public_ip,
-                     'destination_port': self.destination_port,
-                     'protocol': self.protocol,
-                     'auth_attempts': self.get_number_of_login_attempts(),
-                     'session_ended': session_ended
-                     }
+                 'duration': int((datetime.utcnow() - self.timestamp).total_seconds()),
+                 'session_id': self.id,
+                 'source_ip': self.source_ip,
+                 'source_port': self.source_port,
+                 'destination_ip': heralding.honeypot.Honeypot.public_ip,
+                 'destination_port': self.destination_port,
+                 'protocol': self.protocol,
+                 'auth_attempts': self.get_number_of_login_attempts(),
+                 'session_ended': session_ended
+                 }
         return entry
 
     def end_session(self):

--- a/heralding/reporting/curiosum_integration.py
+++ b/heralding/reporting/curiosum_integration.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 class CuriosumIntegration(BaseLogger):
     def __init__(self, port):
-        super(CuriosumIntegration, self).__init__()
+        super().__init__()
 
         zmq_socket = 'tcp://127.0.0.1:{0}'.format(port)
 
@@ -60,7 +60,7 @@ class CuriosumIntegration(BaseLogger):
         self._no_block_send('session_ended', message)
 
     def _execute_regulary(self):
-        if ((datetime.now() - self.last_listen_ports_transmit).total_seconds() > 5):
+        if (datetime.now() - self.last_listen_ports_transmit).total_seconds() > 5:
             self._no_block_send('listen_ports', self.listen_ports)
             self.last_listen_ports_transmit = datetime.now()
 

--- a/heralding/reporting/hpfeeds_logger.py
+++ b/heralding/reporting/hpfeeds_logger.py
@@ -36,9 +36,9 @@ class HpFeedsLogger(BaseLogger):
         if not self._initial_connection_happend:
             self.hp_connection = hpfeeds.new(self.host, self.port, self.ident, self.secret, True)
             self._initial_connection_happend = True
-            logger.info('HpFeeds logger connected to %s:%s.',self.host, self.port)
+            logger.info('HpFeeds logger connected to %s:%s.', self.host, self.port)
         # after we established that we can connect enter the subscribe and enter the polling loop
-        super(HpFeedsLogger, self).start()
+        super().start()
 
     def loggerStopped(self):
         self.stop()

--- a/heralding/reporting/reporting_relay.py
+++ b/heralding/reporting/reporting_relay.py
@@ -39,17 +39,19 @@ class ReportingRelay:
     @staticmethod
     def logAuthAttempt(data):
         ReportingRelay._logQueue.put({'message_type': 'auth',
-                                        'content': data})
+                                      'content': data})
+
     @staticmethod
     def logSessionInfo(data):
         if ReportingRelay._logQueue is not None:
             ReportingRelay._logQueue.put({'message_type': 'session_info',
-                                        'content': data})
+                                          'content': data})
+
     @staticmethod
     def logListenPorts(data):
         if ReportingRelay._logQueue is not None:
             ReportingRelay._logQueue.put({'message_type': 'listen_ports',
-                                        'content': data})
+                                          'content': data})
 
     def start(self):
         self.internalReportingPublisher.bind(SocketNames.INTERNAL_REPORTING.value)

--- a/heralding/tests/test_hpfeeds.py
+++ b/heralding/tests/test_hpfeeds.py
@@ -30,4 +30,3 @@ class FtpTests(unittest.TestCase):
         secret = "toosecret"
 
         HpFeedsLogger(session_channel, auth_channel, host, port, ident, secret)
-

--- a/heralding/tests/test_smtp.py
+++ b/heralding/tests/test_smtp.py
@@ -66,7 +66,6 @@ class SmtpTests(unittest.TestCase):
         smtp_task = self.loop.run_in_executor(None, smtp_connection)
         self.loop.run_until_complete(smtp_task)
 
-
     def test_AUTH_CRAM_MD5_reject(self):
         """ Makes sure the server rejects all invalid login attempts that use the
             CRAM-MD5 Authentication method.
@@ -94,7 +93,6 @@ class SmtpTests(unittest.TestCase):
         smtp_task = self.loop.run_in_executor(None, smtp_auth_cram_md5)
         self.loop.run_until_complete(smtp_task)
 
-
     def test_AUTH_PLAIN_reject(self):
         """ Makes sure the server rejects all invalid login attempts that use the PLAIN Authentication method.
         """
@@ -115,7 +113,6 @@ class SmtpTests(unittest.TestCase):
 
         smtp_task = self.loop.run_in_executor(None, smtp_auth_plain_reject)
         self.loop.run_until_complete(smtp_task)
-
 
     def test_AUTH_LOGIN_reject(self):
         """ Makes sure the server rejects all invalid login attempts that use the LOGIN Authentication method.

--- a/heralding/tests/test_socks5.py
+++ b/heralding/tests/test_socks5.py
@@ -1,0 +1,68 @@
+# Copyright (C) 2018 Roman Samoilenko <ttahabatt@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+import unittest
+
+import heralding.capabilities.socks5 as socks
+from heralding.reporting.reporting_relay import ReportingRelay
+
+
+class Socks5Tests(unittest.TestCase):
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(None)
+
+        self.reporting_relay = ReportingRelay()
+        self.reporting_relay_task = self.loop.run_in_executor(None, self.reporting_relay.start)
+
+    def tearDown(self):
+        self.reporting_relay.stop()
+        # We give reporting_relay a chance to be finished
+        self.loop.run_until_complete(self.reporting_relay_task)
+
+        self.server.close()
+        self.loop.run_until_complete(self.server.wait_closed())
+
+        self.loop.close()
+
+    def test_socks_authentication(self):
+        async def socks_auth():
+            reader, writer = await asyncio.open_connection('127.0.0.1', 8888,
+                                                           loop=self.loop)
+
+            # Greeting to the server. version+authmethod number+authmethod
+            client_greeting = socks.SOCKS_VERSION + b"\x01" + socks.AUTH_METHOD
+            writer.write(client_greeting)
+
+            # Receive version+chosen authmethod
+            _ = await reader.read(2)
+
+            # Send credentials.
+            # version+username len+username+password len+password
+            credentials = b"\x05\x08username\x08password"
+            writer.write(credentials)
+
+            # Receive authmethod+\xff
+            res = await reader.read(2)
+            self.assertEqual(res, socks.AUTH_METHOD + socks.SOCKS_FAIL)
+
+        options = {'enabled': 'True', 'port': 8888, 'timeout': 30}
+        capability = socks.Socks5(options, self.loop)
+
+        server_coro = asyncio.start_server(capability.handle_session, '127.0.0.1',
+                                           8888, loop=self.loop)
+        self.server = self.loop.run_until_complete(server_coro)
+        self.loop.run_until_complete(socks_auth())


### PR DESCRIPTION
Socks5(#72) username/password authentication is implemented according to [RFC1928](https://www.ietf.org/rfc/rfc1928.txt) and [RFC1929](https://tools.ietf.org/html/rfc1929).
PEP8 cleanups.
How to test:
1. `hydra -I -l kajoj -P passlist.txt socks5://localhost`
2. `curl --socks5 127.0.0.1:1080 -U kajoj:pasword check-host.net`