### PR TITLE
Proof of concept for test refactoring.

### DIFF
--- a/heralding/tests/common.py
+++ b/heralding/tests/common.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2018 Roman Samoilenko <ttahabatt@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+import unittest
+
+from heralding.reporting.reporting_relay import ReportingRelay
+
+
+class BaseCapabilityTests(unittest.TestCase):
+    server = None  
+
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(None)
+
+        self.reporting_relay = ReportingRelay()
+        self.reporting_relay_task = self.loop.run_in_executor(None, self.reporting_relay.start)
+
+    def tearDown(self):
+        self.reporting_relay.stop()
+        # We give reporting_relay a chance to be finished
+        self.loop.run_until_complete(self.reporting_relay_task)
+
+        self.server.close()
+        self.loop.run_until_complete(self.server.wait_closed())
+
+        self.loop.close()
+
+    def capability_test(self, capability_class, authfunc, options):
+        capability = capability_class(options, self.loop)
+
+        server_coro = asyncio.start_server(capability.handle_session, '127.0.0.1',
+                                           8888, loop=self.loop)
+        self.server = self.loop.run_until_complete(server_coro)
+
+        if asyncio.iscoroutinefunction(authfunc):
+            self.loop.run_until_complete(authfunc())
+        else:
+            capability_task = self.loop.run_in_executor(None, authfunc)
+            self.loop.run_until_complete(capability_task)

--- a/heralding/tests/common.py
+++ b/heralding/tests/common.py
@@ -39,7 +39,7 @@ class BaseCapabilityTests(unittest.TestCase):
 
         self.loop.close()
 
-    def capability_test(self, capability_class, authfunc, options):
+    def capability_check(self, capability_class, authfunc, options):
         capability = capability_class(options, self.loop)
 
         server_coro = asyncio.start_server(capability.handle_session, '127.0.0.1',

--- a/heralding/tests/test_ftp.py
+++ b/heralding/tests/test_ftp.py
@@ -20,27 +20,11 @@ import ftplib
 from ftplib import FTP
 
 from heralding.capabilities import ftp
+from heralding.tests.common import BaseCapabilityTests
 from heralding.reporting.reporting_relay import ReportingRelay
 
 
-class FtpTests(unittest.TestCase):
-    def setUp(self):
-        self.loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(None)
-
-        self.reporting_relay = ReportingRelay()
-        self.reporting_relay_task = self.loop.run_in_executor(None, self.reporting_relay.start)
-
-    def tearDown(self):
-        self.reporting_relay.stop()
-        # We give reporting_relay a chance to be finished
-        self.loop.run_until_complete(self.reporting_relay_task)
-
-        self.server.close()
-        self.loop.run_until_complete(self.server.wait_closed())
-
-        self.loop.close()
-
+class FtpTests(BaseCapabilityTests):
     def test_login(self):
         """Testing different login combinations"""
 
@@ -56,11 +40,4 @@ class FtpTests(unittest.TestCase):
 
         options = {'enabled': 'True', 'port': 0, 'banner': 'Test Banner', 'users': {'test': 'test'},
                    'protocol_specific_data': {'max_attempts': 3, 'banner': 'test banner', 'syst_type': 'Test Type'}}
-
-        ftp_capability = ftp.ftp(options, self.loop)
-
-        server_coro = asyncio.start_server(ftp_capability.handle_session, '0.0.0.0', 8888, loop=self.loop)
-        self.server = self.loop.run_until_complete(server_coro)
-
-        ftp_task = self.loop.run_in_executor(None, ftp_login)
-        self.loop.run_until_complete(ftp_task)
+        self.capability_test(ftp.ftp, ftp_login, options)

--- a/heralding/tests/test_ftp.py
+++ b/heralding/tests/test_ftp.py
@@ -13,15 +13,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import asyncio
-import unittest
-
 import ftplib
 from ftplib import FTP
 
 from heralding.capabilities import ftp
 from heralding.tests.common import BaseCapabilityTests
-from heralding.reporting.reporting_relay import ReportingRelay
 
 
 class FtpTests(BaseCapabilityTests):
@@ -40,4 +36,4 @@ class FtpTests(BaseCapabilityTests):
 
         options = {'enabled': 'True', 'port': 0, 'banner': 'Test Banner', 'users': {'test': 'test'},
                    'protocol_specific_data': {'max_attempts': 3, 'banner': 'test banner', 'syst_type': 'Test Type'}}
-        self.capability_test(ftp.ftp, ftp_login, options)
+        self.capability_check(ftp.ftp, ftp_login, options)


### PR DESCRIPTION
This PR is intended to show the possible beginning of tests refactoring and **shouldn't be merged**.

Almost all our tests have similar `setUp` and `tearDown` methods. I think it is a little bit repetitive.
We also have much repetitive code in the ordinary tests. 

What do you think? Can we continue to develop this idea?