### PR TITLE
Pickup destination address from socket

### DIFF
--- a/heralding/capabilities/handlerbase.py
+++ b/heralding/capabilities/handlerbase.py
@@ -43,15 +43,16 @@ class HandlerBase:
         else:
             self.timeout = 30
 
-    def create_session(self, address):
+    def create_session(self, address, dest_address):
         protocol = self.__class__.__name__.lower()
         session = Session(address[0], address[1], protocol, self.users)
         self.sessions[session.id] = session
         HandlerBase.global_sessions += 1
-        session.destination_port = self.port
+        session.destination_ip = dest_address[0]
+        session.destination_port = dest_address[1]
         logger.debug(
-            'Accepted %s session on port %s from %s:%s. (%s)', protocol, self.port, address[
-                0],
+            'Accepted %s session on %s:%s from %s:%s. (%s)',
+                protocol, dest_address[0], dest_address[1], address[0],
             address[1], str(session.id))
         logger.debug('Size of session list for %s: %s',
                      protocol, len(self.sessions))
@@ -74,13 +75,15 @@ class HandlerBase:
 
     async def handle_session(self, reader, writer):
         address = writer.get_extra_info('peername')
+        dest_address = writer.get_extra_info('sockname')
+
         if HandlerBase.global_sessions > HandlerBase.MAX_GLOBAL_SESSIONS:
             protocol = self.__class__.__name__.lower()
             logger.warning(
                 'Got %s session on port %s from %s:%s, but not handling it because the global session limit has '
                 'been reached', protocol, self.port, *address)
         else:
-            session = self.create_session(address)
+            session = self.create_session(address, dest_address)
             try:
                 await asyncio.wait_for(self.execute_capability(reader, writer, session),
                                        timeout=self.timeout, loop=self.loop)

--- a/heralding/capabilities/handlerbase.py
+++ b/heralding/capabilities/handlerbase.py
@@ -45,11 +45,9 @@ class HandlerBase:
 
     def create_session(self, address, dest_address):
         protocol = self.__class__.__name__.lower()
-        session = Session(address[0], address[1], protocol, self.users)
+        session = Session(address[0], address[1], protocol, self.users, dest_address[1], dest_address[0])
         self.sessions[session.id] = session
         HandlerBase.global_sessions += 1
-        session.destination_ip = dest_address[0]
-        session.destination_port = dest_address[1]
         logger.debug(
             'Accepted %s session on %s:%s from %s:%s. (%s)',
                 protocol, dest_address[0], dest_address[1], address[0],

--- a/heralding/capabilities/ssh.py
+++ b/heralding/capabilities/ssh.py
@@ -35,6 +35,7 @@ class SSH(asyncssh.SSHServer, HandlerBase):
     def connection_made(self, conn):
         SSH.connections_list.append(conn)
         self.address = conn.get_extra_info('peername')
+        self.dest_address = conn.get_extra_info('sockname')
         self.handle_connection()
         logger.debug('SSH connection received from %s.' % conn.get_extra_info('peername')[0])
 
@@ -62,7 +63,7 @@ class SSH(asyncssh.SSHServer, HandlerBase):
                 'Got {0} session on port {1} from {2}:{3}, but not handling it because the global session limit has '
                 'been reached'.format(protocol, self.port, *self.address))
         else:
-            self.session = self.create_session(self.address)
+            self.session = self.create_session(self.address, self.dest_address)
 
     @staticmethod
     def change_server_banner(banner):

--- a/heralding/misc/session.py
+++ b/heralding/misc/session.py
@@ -25,13 +25,16 @@ logger = logging.getLogger(__name__)
 
 
 class Session:
-    def __init__(self, source_ip, source_port, protocol, users, destination_port=None, destination_ip=None):
+    def __init__(self, source_ip, source_port, protocol, users, destination_port=None, destination_ip=''):
 
         self.id = uuid.uuid4()
         self.source_ip = source_ip
         self.source_port = source_port
         self.protocol = protocol
-        self.destination_ip = destination_ip
+        if heralding.honeypot.Honeypot.public_ip:
+            self.destination_ip = heralding.honeypot.Honeypot.public_ip
+        else:
+            self.destination_ip = destination_ip
         self.destination_port = destination_port
         self.timestamp = datetime.utcnow()
         self.login_attempts = 0
@@ -65,7 +68,7 @@ class Session:
                  'auth_id': uuid.uuid4(),
                  'source_ip': self.source_ip,
                  'source_port': self.source_port,
-                 'destination_ip': heralding.honeypot.Honeypot.public_ip,
+                 'destination_ip': self.destination_ip,
                  'destination_port': self.destination_port,
                  'protocol': self.protocol,
                  'username': None,
@@ -89,7 +92,7 @@ class Session:
                  'session_id': self.id,
                  'source_ip': self.source_ip,
                  'source_port': self.source_port,
-                 'destination_ip': heralding.honeypot.Honeypot.public_ip,
+                 'destination_ip': self.destination_ip,
                  'destination_port': self.destination_port,
                  'protocol': self.protocol,
                  'auth_attempts': self.get_number_of_login_attempts(),


### PR DESCRIPTION
I noticed that a session contains a `destination_ip` but that it isn't used, or event set. This PR:

 * Sets `destination_ip` to the `public_ip` - if one is set.
 * Sets `destination_ip` to the destination ip of the socket (`socket.getsockname()`) otherwise
 * Uses `destination_ip` when logging events rather than forcing it to the `public_ip`.