### PR TITLE
Fix for wrong password entry in log_session.json

### DIFF
--- a/heralding/misc/session.py
+++ b/heralding/misc/session.py
@@ -93,7 +93,7 @@ class Session:
         self.auth_attempts.append({
             'timestamp': entry['timestamp'].strftime('%Y-%m-%d %H:%M:%S.%f'),
             'username': entry['username'],
-            'password': entry['username'],
+            'password': entry['password'],
         })
 
         self.activity()


### PR DESCRIPTION
In the `log_session.json` , the password entry is same as the username entry. This PR fixes it.