### PR TITLE
Fix RDP Connection issue in some MSRDP clients

### DIFF
--- a/heralding/libs/msrdp/parser.py
+++ b/heralding/libs/msrdp/parser.py
@@ -163,8 +163,10 @@ class x224ConnectionRequestPDU():
     pos = tpktPDUParser().parse(raw_data, 0)
     self.pduType, pos = UInt8(raw_data, pos + 1).read()  # ignore lenght byte
     _, pos = RawBytes(raw_data, None, 5, pos).readRaw()  # consume 5bytes
-    self.cookie, pos = RawBytes(raw_data, None, None,
-                                pos).readUntil(b"\x0d\x0a")
+    # cookie is optional
+    if b"Cookie: mstshash=" in raw_data:
+      self.cookie, pos = RawBytes(raw_data, None, None,
+                                  pos).readUntil(b"\x0d\x0a")
     # parse nego req if present
     if raw_data[pos:] != b'':
       _, pos = RawBytes(raw_data, None, 4, pos).readRaw()

--- a/heralding/libs/msrdp/pdu.py
+++ b/heralding/libs/msrdp/pdu.py
@@ -148,7 +148,7 @@ class MCSChannelJoinConfirmPDU():
 
   def __init__(self, initiator, channelID):
     self.initiator = Uint16BE.pack(initiator)
-    self.channelID = Uint32BE.pack(channelID)
+    self.channelID = Uint16BE.pack(channelID)
 
   def generate(self):
     res = b'\x3e\x00'


### PR DESCRIPTION
The cookie handling method of `x224ConnectionRequestPDU` was wrong.
This PR corrects it.