### PR TITLE
Add Dockerfile, Update Readme & Add Docker guide

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.7-slim-stretch as base
+
+COPY . .
+RUN apt-get update && apt-get install -y libpq-dev gcc \
+    && pip install --user --no-cache-dir -r requirements.txt
+
+RUN python setup.py install --user
+
+FROM python:3.7-slim-stretch
+COPY --from=base /root/.local /root/.local
+
+ENV PATH=/root/.local/bin:$PATH
+
+CMD ["heralding" ]
+EXPOSE 21 22 23 25 80 110 143 443 993 995 1080 2222 3306 3389 5432 5900

--- a/README.rst
+++ b/README.rst
@@ -147,6 +147,47 @@ And finally start the honeypot:
   cd tmp
   sudo heralding
   
+Docker Build
+-------------
+1.Checkout the code:
+
+.. code-block:: shell
+
+  cd ~
+  git clone https://github.com/johnnykv/heralding.git
+  cd heralding
+
+2.Build new Docker image and run it (Http localhost expose example of port 80 to localhost:8080):
+
+.. code-block:: shell
+
+  sudo docker build -t heralding .
+
+  sudo docker run -p 8080:80 heralding
+
+Visit your application in a browser at http://localhost:8080
+
+3.Check the log files:
+
+.. code-block:: shell
+
+  sudo docker ps
+
+
+We need to copy the CONTAINER ID of our heralding image. Looking like 0beb67f1e92c.
+
+.. code-block:: shell
+
+  sudo docker exec -it 0beb67f1e92c bash
+
+
+And now you are in the work directory, you can read the log files by typing cat and the name of the file. Example:
+
+.. code-block:: shell
+
+  cat log_auth.csv
+
+
 Pcaps
 -----
 


### PR DESCRIPTION
It is easier to run and test Heralding with Docker as it is simple, consistent and efficient.

Changes proposed in this pull request:
- Add Multistage Dockerfile in order to have small image size.
- Add guide for building Docker image in main Readme.