### PR TITLE
compatibility with python3.9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ About
 Sometimes you just want a simple honeypot that collects credentials, nothing more. Heralding is that honeypot!
 Currently the following protocols are supported: ftp, telnet, ssh, http, https, pop3, pop3s, imap, imaps, smtp, vnc, postgresql and socks5.
 
-**You need Python 3.6.0 or higher.**
+**You need Python 3.7.0 or higher.**
 
 Starting the honeypot
 -----------------------

--- a/bin/heralding
+++ b/bin/heralding
@@ -84,7 +84,7 @@ class LogFilter(logging.Filter):
 
 
 def break_if_python_not_supported():
-  if sys.version_info[0:2] < (3, 6):
+  if sys.version_info[0:2] < (3, 7):
     raise Exception(
         "Wrong python version! Your Python interpreter must be 3.6.0 or above!")
 

--- a/heralding/misc/common.py
+++ b/heralding/misc/common.py
@@ -35,8 +35,8 @@ def on_unhandled_task_exception(task):
 async def cancel_all_pending_tasks(loop=None):
   if loop is None:
     loop = asyncio.get_event_loop()
-  pending = asyncio.Task.all_tasks(loop=loop)
-  pending.remove(asyncio.Task.current_task(loop=loop))
+  pending = asyncio.all_tasks(loop=loop)
+  pending.remove(asyncio.current_task(loop=loop))
   for task in pending:
     # We give task only 1 second to die.
     if not task.done():

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-psycopg2
+psycopg2-binary
 PyMySQL==0.9.3
 pymysql
 pycryptodome

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ asyncssh>=2.0.0
 pyOpenSSL
 pyaml
 pyzmq
-psycopg2
+psycopg2-binary
 hpfeeds3
 rsa
 requests


### PR DESCRIPTION
`asyncio.Task.all_tasks()` is deprecated since 3.7, removed in 3.9 and replaced by `asyncio.all_taskts()` 

Same for `asyncio.Task.current_task()`